### PR TITLE
Fix error when DB response is null

### DIFF
--- a/src/Attachment/index.ts
+++ b/src/Attachment/index.ts
@@ -61,6 +61,10 @@ export class Attachment implements AttachmentContract {
    * Create attachment instance from the database response
    */
   public static fromDbResponse(response: any) {
+    if (response === null) {
+      return null
+    }
+
     const attributes = typeof response === 'string' ? JSON.parse(response) : response
 
     /**

--- a/test/attachment.spec.ts
+++ b/test/attachment.spec.ts
@@ -44,8 +44,8 @@ test.group('Attachment | fromDbResponse', (group) => {
       })
     )
 
-    assert.isTrue(attachment.isPersisted)
-    assert.isFalse(attachment.isLocal)
+    assert.isTrue(attachment?.isPersisted)
+    assert.isFalse(attachment?.isLocal)
   })
 
   test('save method should result in noop when attachment is created from db response', async (assert) => {
@@ -58,8 +58,13 @@ test.group('Attachment | fromDbResponse', (group) => {
       })
     )
 
-    await attachment.save()
-    assert.equal(attachment.name, 'foo.jpg')
+    await attachment?.save()
+    assert.equal(attachment?.name, 'foo.jpg')
+  })
+
+  test('Attachment should be null when db response is null', async (assert) => {
+    const attachment = Attachment.fromDbResponse(null)
+    assert.isNull(attachment)
   })
 
   test('delete persisted file', async (assert) => {
@@ -72,8 +77,8 @@ test.group('Attachment | fromDbResponse', (group) => {
       })
     )
 
-    await attachment.delete()
-    assert.isTrue(attachment.isDeleted)
+    await attachment?.delete()
+    assert.isTrue(attachment?.isDeleted)
   })
 
   test('compute file url', async (assert) => {
@@ -86,10 +91,10 @@ test.group('Attachment | fromDbResponse', (group) => {
       })
     )
 
-    attachment.setOptions({ preComputeUrl: true })
+    attachment?.setOptions({ preComputeUrl: true })
 
-    await attachment.computeUrl()
-    assert.match(attachment.url, /\/uploads\/foo\.jpg\?signature=/)
+    await attachment?.computeUrl()
+    assert.match(attachment?.url!, /\/uploads\/foo\.jpg\?signature=/)
   })
 
   test('compute file url from a custom method', async (assert) => {
@@ -102,14 +107,14 @@ test.group('Attachment | fromDbResponse', (group) => {
       })
     )
 
-    attachment.setOptions({
+    attachment?.setOptions({
       preComputeUrl: async (_, file) => {
         return `/${file.name}`
       },
     })
 
-    await attachment.computeUrl()
-    assert.equal(attachment.url, '/foo.jpg')
+    await attachment?.computeUrl()
+    assert.equal(attachment?.url, '/foo.jpg')
   })
 })
 


### PR DESCRIPTION
## Proposed changes

This PR resolves the issue with the `fromDbResponse` static method when response from DB is `null`. Fixes #6 

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/attachment-lite/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
