### PR TITLE
allow column options to override defaults

### DIFF
--- a/src/Attachment/decorator.ts
+++ b/src/Attachment/decorator.ts
@@ -215,10 +215,10 @@ export const attachment: AttachmentDecorator = (options) => {
      * Define the property as a column too
      */
     Model.$addColumn(property, {
-      ...columnOptions,
       consume: (value) => (value ? Attachment.fromDbResponse(value) : null),
       prepare: (value) => (value ? JSON.stringify(value.toObject()) : null),
       serialize: (value) => (value ? value.toJSON() : null),
+      ...columnOptions,
     })
 
     /**


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Allows the user to override column options on the attachment decorator. Related to this issue: https://github.com/adonisjs/attachment-lite/issues/21

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/adonisjs/attachment-lite/blob/master/.github/CONTRIBUTING.md) doc
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
