### PR TITLE
feat: add multiple option to attachment decorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build
 dist
 shrinkwrap.yaml
 package-lock.json
+pnpm-lock.yaml

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ config.json
 package.json
 *.html
 *.txt
+test-helpers/__app

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ If you are creating the column for the first time, make sure that you use the JS
   public async up() {
     this.schema.createTable(this.tableName, (table) => {
       table.increments()
-      table.json('avatar') // <-- Use a JSON data type
+      table.json('avatar') // <-- Use JSON data type for single attachment fields
+      table.json('photos') // <-- Use JSON data type for multiple attachment fields
     })
   }
 ```
@@ -82,6 +83,7 @@ node ace make:migration change_avatar_column_to_json --table=users
   public async up() {
     this.schema.alterTable(this.tableName, (table) => {
       table.json('avatar').alter() // <-- Alter the column definition
+      table.json('photos').alter() // <-- Alter the column definition
     })
   }
 ```
@@ -100,6 +102,9 @@ import {
 class User extends BaseModel {
   @attachment()
   public avatar: AttachmentContract
+
+  @attachment({ multiple: true })
+  public photos: AttachmentContract[]
 }
 ```
 
@@ -114,6 +119,20 @@ class UsersController {
     const user = new User()
 
     user.avatar = Attachment.fromFile(avatar)
+    await user.save()
+  }
+
+  // Add attachment to a multiple attachment field
+  public storePhoto({ request, auth }: HttpContextContract) {
+    const photo = request.file('photo')!
+    auth.user.photos.push(Attachment.fromFile(avatar))
+    await user.save()
+  }
+
+  // Remove attachment from a multiple attachment field
+  public deletePhoto({ request, auth }: HttpContextContract) {
+    const photo = request.input('photo')!
+    auth.user.photos = user.photos.filter(item => item.name !== photo.name)
     await user.save()
   }
 }

--- a/adonis-typings/attachment.ts
+++ b/adonis-typings/attachment.ts
@@ -136,7 +136,10 @@ declare module '@ioc:Adonis/Addons/AttachmentLite' {
    */
   export type AttachmentDecorator = (
     options?: AttachmentOptions & Partial<ColumnOptions>
-  ) => <TKey extends string, TTarget extends { [K in TKey]?: AttachmentContract | null }>(
+  ) => <
+    TKey extends string,
+    TTarget extends { [K in TKey]?: AttachmentContract[] | AttachmentContract | null }
+  >(
     target: TTarget,
     property: TKey
   ) => void

--- a/adonis-typings/attachment.ts
+++ b/adonis-typings/attachment.ts
@@ -38,6 +38,7 @@ declare module '@ioc:Adonis/Addons/AttachmentLite' {
     preComputeUrl?:
       | boolean
       | ((disk: DriverContract, attachment: AttachmentContract) => Promise<string>)
+    multiple?: boolean
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "author": "virk,adonisjs",
   "license": "MIT",
   "devDependencies": {
+    "@adonisjs/bodyparser": "^8.1.7",
     "@adonisjs/core": "^5.8.2",
     "@adonisjs/lucid": "^18.0.0",
     "@adonisjs/mrm-preset": "^5.0.3",

--- a/src/Attachment/index.ts
+++ b/src/Attachment/index.ts
@@ -88,6 +88,7 @@ export class Attachment implements AttachmentContract {
        * Files fetched from DB are always persisted
        */
       attachment.isPersisted = true
+      return attachment
     })
 
     return multiple ? attachments : attachments[0]

--- a/test/attachment-decorator-multiple.spec.ts
+++ b/test/attachment-decorator-multiple.spec.ts
@@ -1,0 +1,1542 @@
+/*
+ * @adonisjs/attachment-lite
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import 'reflect-metadata'
+
+import { test } from '@japa/runner'
+import { join } from 'path'
+import supertest from 'supertest'
+import { createServer } from 'http'
+import { ApplicationContract } from '@ioc:Adonis/Core/Application'
+import { AttachmentContract } from '@ioc:Adonis/Addons/AttachmentLite'
+import { BodyParserMiddleware } from '@adonisjs/bodyparser/build/src/BodyParser'
+
+import { Attachment } from '../src/Attachment'
+import { attachment } from '../src/Attachment/decorator'
+import { setup, cleanup, setupApplication } from '../test-helpers'
+
+let app: ApplicationContract
+
+test.group('@attachment | multiple | insert', (group) => {
+  group.setup(async () => {
+    app = await setupApplication()
+    await setup(app)
+
+    app.container.resolveBinding('Adonis/Core/Route').commit()
+    Attachment.setDrive(app.container.resolveBinding('Adonis/Core/Drive'))
+  })
+
+  group.each.teardown(async () => {
+    await app.container.resolveBinding('Adonis/Lucid/Database').connection().truncate('users')
+  })
+
+  group.teardown(async () => {
+    await cleanup(app)
+  })
+
+  test('save attachment to the db and on disk', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ multiple: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')!
+
+        const user = new User()
+        user.username = 'virk'
+        user.photos = [Attachment.fromFile(file)]
+        await user.save()
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    const users = await User.all()
+
+    assert.lengthOf(users, 1)
+    assert.instanceOf(users[0].photos[0], Attachment)
+    assert.isUndefined(users[0].photos[0]?.url)
+    assert.deepEqual(users[0].photos[0]?.toJSON(), body.avatar)
+
+    assert.isTrue(await Drive.exists(body.avatar.name))
+  })
+
+  test('cleanup attachments when save call fails', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ multiple: true })
+      public photos: AttachmentContract[]
+    }
+
+    await User.create({ username: 'virk' })
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')!
+
+        const user = new User()
+        user.username = 'virk'
+        user.photos = [Attachment.fromFile(file)]
+
+        try {
+          await user.save()
+        } catch (error) {}
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    const users = await User.all()
+
+    assert.lengthOf(users, 1)
+    assert.isNull(users[0].photos[0])
+    assert.isFalse(await Drive.exists(body.avatar.name))
+  })
+})
+
+test.group('@attachment | multiple | insert with transaction', (group) => {
+  group.setup(async () => {
+    app = await setupApplication()
+    await setup(app)
+
+    app.container.resolveBinding('Adonis/Core/Route').commit()
+    Attachment.setDrive(app.container.resolveBinding('Adonis/Core/Drive'))
+  })
+
+  group.each.teardown(async () => {
+    await app.container.resolveBinding('Adonis/Lucid/Database').connection().truncate('users')
+  })
+
+  group.teardown(async () => {
+    await cleanup(app)
+  })
+
+  test('save attachment to the db and on disk', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+    const Db = app.container.resolveBinding('Adonis/Lucid/Database')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ multiple: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')!
+        const trx = await Db.transaction()
+
+        const user = new User()
+        user.username = 'virk'
+        user.photos = [Attachment.fromFile(file)]
+        await user.useTransaction(trx).save()
+
+        await trx.commit()
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    const users = await User.all()
+
+    assert.lengthOf(users, 1)
+    assert.instanceOf(users[0].photos[0], Attachment)
+    assert.deepEqual(users[0].photos[0]?.toJSON(), body.avatar)
+
+    assert.isTrue(await Drive.exists(body.avatar.name))
+  })
+
+  test('cleanup attachments when save call fails', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+    const Db = app.container.resolveBinding('Adonis/Lucid/Database')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ multiple: true })
+      public photos: AttachmentContract[]
+    }
+
+    await User.create({ username: 'virk' })
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')!
+        const trx = await Db.transaction()
+
+        const user = new User()
+        user.username = 'virk'
+        user.photos = [Attachment.fromFile(file)]
+
+        try {
+          await user.useTransaction(trx).save()
+          await trx.commit()
+        } catch (error) {
+          await trx.rollback()
+        }
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    const users = await User.all()
+
+    assert.lengthOf(users, 1)
+    assert.isNull(users[0].photos[0])
+    assert.isFalse(await Drive.exists(body.avatar.name))
+  })
+
+  test('cleanup attachments when rollback is called after success', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+    const Db = app.container.resolveBinding('Adonis/Lucid/Database')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ multiple: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')!
+        const trx = await Db.transaction()
+
+        const user = new User()
+        user.username = 'virk'
+        user.photos = [Attachment.fromFile(file)]
+        await user.useTransaction(trx).save()
+        await trx.rollback()
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    const users = await User.all()
+
+    assert.lengthOf(users, 0)
+    assert.isFalse(await Drive.exists(body.avatar.name))
+  })
+})
+
+test.group('@attachment | multiple | update', (group) => {
+  group.setup(async () => {
+    app = await setupApplication()
+    await setup(app)
+
+    app.container.resolveBinding('Adonis/Core/Route').commit()
+    Attachment.setDrive(app.container.resolveBinding('Adonis/Core/Drive'))
+  })
+
+  group.each.teardown(async () => {
+    await app.container.resolveBinding('Adonis/Lucid/Database').connection().truncate('users')
+  })
+
+  group.teardown(async () => {
+    await cleanup(app)
+  })
+
+  test('save attachment to the db and on disk', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ multiple: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')!
+
+        const user = await User.firstOrNew({ username: 'virk' }, {})
+        user.photos = [Attachment.fromFile(file)]
+        await user.save()
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body: firstResponse } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    const { body: secondResponse } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    const users = await User.all()
+
+    assert.lengthOf(users, 1)
+    assert.instanceOf(users[0].photos[0], Attachment)
+    assert.deepEqual(users[0].photos[0]?.toJSON(), secondResponse.avatar)
+    assert.isFalse(await Drive.exists(firstResponse.avatar.name))
+    assert.isTrue(await Drive.exists(secondResponse.avatar.name))
+  })
+
+  test('cleanup attachments when save call fails', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ multiple: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')!
+
+        const user = new User()
+        user.username = 'virk'
+        user.photos = [Attachment.fromFile(file)]
+
+        try {
+          await user.save()
+        } catch {}
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body: firstResponse } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    const { body: secondResponse } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    const users = await User.all()
+
+    assert.lengthOf(users, 1)
+    assert.instanceOf(users[0].photos[0], Attachment)
+    assert.deepEqual(users[0].photos[0]?.toJSON(), firstResponse.avatar)
+    assert.isTrue(await Drive.exists(firstResponse.avatar.name))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.name))
+  })
+})
+
+test.group('@attachment | multiple | update with transaction', (group) => {
+  group.setup(async () => {
+    app = await setupApplication()
+    await setup(app)
+
+    app.container.resolveBinding('Adonis/Core/Route').commit()
+    Attachment.setDrive(app.container.resolveBinding('Adonis/Core/Drive'))
+  })
+
+  group.each.teardown(async () => {
+    await app.container.resolveBinding('Adonis/Lucid/Database').connection().truncate('users')
+  })
+
+  group.teardown(async () => {
+    await cleanup(app)
+  })
+
+  test('save attachment to the db and on disk', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const Db = app.container.resolveBinding('Adonis/Lucid/Database')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ multiple: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')!
+        const trx = await Db.transaction()
+
+        const user = await User.firstOrNew({ username: 'virk' }, {}, { client: trx })
+        user.photos = [Attachment.fromFile(file)]
+        await user.save()
+        await trx.commit()
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body: firstResponse } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    const { body: secondResponse } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    const users = await User.all()
+
+    assert.lengthOf(users, 1)
+    assert.instanceOf(users[0].photos[0], Attachment)
+    assert.deepEqual(users[0].photos[0]?.toJSON(), secondResponse.avatar)
+    assert.isFalse(await Drive.exists(firstResponse.avatar.name))
+    assert.isTrue(await Drive.exists(secondResponse.avatar.name))
+  })
+
+  test('cleanup attachments when save call fails', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const Db = app.container.resolveBinding('Adonis/Lucid/Database')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ multiple: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')!
+        const trx = await Db.transaction()
+
+        const user = new User()
+        user.username = 'virk'
+        user.photos = [Attachment.fromFile(file)]
+
+        try {
+          await user.useTransaction(trx).save()
+          await trx.commit()
+        } catch {
+          await trx.rollback()
+        }
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body: firstResponse } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    const { body: secondResponse } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    const users = await User.all()
+
+    assert.lengthOf(users, 1)
+    assert.instanceOf(users[0].photos[0], Attachment)
+    assert.deepEqual(users[0].photos[0]?.toJSON(), firstResponse.avatar)
+    assert.isTrue(await Drive.exists(firstResponse.avatar.name))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.name))
+  })
+
+  test('cleanup attachments when rollback is called after success', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const Db = app.container.resolveBinding('Adonis/Lucid/Database')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ multiple: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')!
+        const trx = await Db.transaction()
+
+        const user = await User.firstOrNew({ username: 'virk' }, {}, { client: trx })
+        const isLocal = user.$isLocal
+
+        user.username = 'virk'
+        user.photos = [Attachment.fromFile(file)]
+        await user.useTransaction(trx).save()
+
+        isLocal ? await trx.commit() : await trx.rollback()
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body: firstResponse } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    const { body: secondResponse } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    const users = await User.all()
+
+    assert.lengthOf(users, 1)
+    assert.instanceOf(users[0].photos[0], Attachment)
+    assert.deepEqual(users[0].photos[0]?.toJSON(), firstResponse.avatar)
+    assert.isTrue(await Drive.exists(firstResponse.avatar.name))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.name))
+  })
+})
+
+test.group('@attachment | multiple | resetToNull', (group) => {
+  group.setup(async () => {
+    app = await setupApplication()
+    await setup(app)
+
+    app.container.resolveBinding('Adonis/Core/Route').commit()
+    Attachment.setDrive(app.container.resolveBinding('Adonis/Core/Drive'))
+  })
+
+  group.each.teardown(async () => {
+    await app.container.resolveBinding('Adonis/Lucid/Database').connection().truncate('users')
+  })
+
+  group.teardown(async () => {
+    await cleanup(app)
+  })
+
+  test('save attachment to the db and on disk', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ multiple: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')
+
+        const user = await User.firstOrNew({ username: 'virk' }, {})
+        user.photos = file ? [Attachment.fromFile(file)] : []
+        await user.save()
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body: firstResponse } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    await supertest(server).post('/')
+
+    const users = await User.all()
+
+    assert.lengthOf(users, 1)
+    assert.isNull(users[0].photos[0])
+    assert.isFalse(await Drive.exists(firstResponse.avatar.name))
+  })
+
+  test('do not remove old file when resetting to null fails', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ multiple: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')
+
+        const user = new User()
+        user.username = 'virk'
+        user.photos = file ? [Attachment.fromFile(file)] : []
+
+        try {
+          await user.save()
+        } catch {}
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body: firstResponse } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    await supertest(server).post('/')
+
+    const users = await User.all()
+
+    assert.lengthOf(users, 1)
+    assert.instanceOf(users[0].photos[0], Attachment)
+    assert.deepEqual(users[0].photos[0]?.toJSON(), firstResponse.avatar)
+    assert.isTrue(await Drive.exists(firstResponse.avatar.name))
+  })
+})
+
+test.group('@attachment | multiple | resetToNull with transaction', (group) => {
+  group.setup(async () => {
+    app = await setupApplication()
+    await setup(app)
+
+    app.container.resolveBinding('Adonis/Core/Route').commit()
+    Attachment.setDrive(app.container.resolveBinding('Adonis/Core/Drive'))
+  })
+
+  group.each.teardown(async () => {
+    await app.container.resolveBinding('Adonis/Lucid/Database').connection().truncate('users')
+  })
+
+  group.teardown(async () => {
+    await cleanup(app)
+  })
+
+  test('save attachment to the db and on disk', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const Db = app.container.resolveBinding('Adonis/Lucid/Database')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ multiple: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')
+        const trx = await Db.transaction()
+
+        const user = await User.firstOrNew({ username: 'virk' }, {}, { client: trx })
+        user.photos = file ? [Attachment.fromFile(file)] : []
+        await user.useTransaction(trx).save()
+        await trx.commit()
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body: firstResponse } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    await supertest(server).post('/')
+
+    const users = await User.all()
+
+    assert.lengthOf(users, 1)
+    assert.isNull(users[0].photos[0])
+    assert.isFalse(await Drive.exists(firstResponse.avatar.name))
+  })
+
+  test('do not remove old file when resetting to null fails', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const Db = app.container.resolveBinding('Adonis/Lucid/Database')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ multiple: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')
+        const trx = await Db.transaction()
+
+        const user = new User()
+        user.username = 'virk'
+        user.photos = file ? [Attachment.fromFile(file)] : []
+
+        try {
+          await user.useTransaction(trx).save()
+          await trx.commit()
+        } catch {
+          await trx.rollback()
+        }
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body: firstResponse } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    await supertest(server).post('/')
+
+    const users = await User.all()
+
+    assert.lengthOf(users, 1)
+    assert.instanceOf(users[0].photos[0], Attachment)
+    assert.deepEqual(users[0].photos[0]?.toJSON(), firstResponse.avatar)
+    assert.isTrue(await Drive.exists(firstResponse.avatar.name))
+  })
+
+  test('do not remove old file when rollback was performed after success', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const Db = app.container.resolveBinding('Adonis/Lucid/Database')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ multiple: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')
+        const trx = await Db.transaction()
+
+        const user = await User.firstOrNew({ username: 'virk' }, {}, { client: trx })
+        const isLocal = user.$isLocal
+        user.photos = file ? [Attachment.fromFile(file)] : []
+
+        await user.useTransaction(trx).save()
+        isLocal ? await trx.commit() : await trx.rollback()
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body: firstResponse } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    await supertest(server).post('/')
+
+    const users = await User.all()
+
+    assert.lengthOf(users, 1)
+    assert.instanceOf(users[0].photos[0], Attachment)
+    assert.deepEqual(users[0].photos[0]?.toJSON(), firstResponse.avatar)
+    assert.isTrue(await Drive.exists(firstResponse.avatar.name))
+  })
+})
+
+test.group('@attachment | multiple | delete', (group) => {
+  group.setup(async () => {
+    app = await setupApplication()
+    await setup(app)
+
+    app.container.resolveBinding('Adonis/Core/Route').commit()
+    Attachment.setDrive(app.container.resolveBinding('Adonis/Core/Drive'))
+  })
+
+  group.each.teardown(async () => {
+    await app.container.resolveBinding('Adonis/Lucid/Database').connection().truncate('users')
+  })
+
+  group.teardown(async () => {
+    await cleanup(app)
+  })
+
+  test('delete attachment when model is deleted', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ multiple: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')
+
+        const user = await User.firstOrNew({ username: 'virk' }, {})
+        user.photos = file ? [Attachment.fromFile(file)] : []
+        await user.save()
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body: firstResponse } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    const user = await User.firstOrFail()
+    await user.delete()
+
+    const users = await User.all()
+    assert.lengthOf(users, 0)
+    assert.isFalse(await Drive.exists(firstResponse.avatar.name))
+  })
+
+  test('do not delete attachment when deletion fails', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ multiple: true })
+      public photos: AttachmentContract[]
+    }
+
+    User.before('delete', () => {
+      throw new Error('Failed')
+    })
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')
+
+        const user = await User.firstOrNew({ username: 'virk' }, {})
+        user.photos = file ? [Attachment.fromFile(file)] : []
+        await user.save()
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    const user = await User.firstOrFail()
+    try {
+      await user.delete()
+    } catch {}
+
+    const users = await User.all()
+    assert.lengthOf(users, 1)
+    assert.deepEqual(users[0].photos[0]?.toJSON(), body.avatar)
+    assert.isTrue(await Drive.exists(body.avatar.name))
+  })
+})
+
+test.group('@attachment | multiple | delete with transaction', (group) => {
+  group.setup(async () => {
+    app = await setupApplication()
+    await setup(app)
+
+    app.container.resolveBinding('Adonis/Core/Route').commit()
+    Attachment.setDrive(app.container.resolveBinding('Adonis/Core/Drive'))
+  })
+
+  group.each.teardown(async () => {
+    await app.container.resolveBinding('Adonis/Lucid/Database').connection().truncate('users')
+  })
+
+  group.teardown(async () => {
+    await cleanup(app)
+  })
+
+  test('delete attachment when model is deleted', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const Db = app.container.resolveBinding('Adonis/Lucid/Database')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ multiple: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')
+
+        const user = await User.firstOrNew({ username: 'virk' }, {})
+        user.photos = file ? [Attachment.fromFile(file)] : []
+        await user.save()
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body: firstResponse } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    const user = await User.firstOrFail()
+    const trx = await Db.transaction()
+    await user.useTransaction(trx).delete()
+    assert.isTrue(await Drive.exists(firstResponse.avatar.name))
+
+    await trx.commit()
+
+    const users = await User.all()
+    assert.lengthOf(users, 0)
+    assert.isFalse(await Drive.exists(firstResponse.avatar.name))
+  })
+
+  test('do not delete attachment when deletion fails', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const Db = app.container.resolveBinding('Adonis/Lucid/Database')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ multiple: true })
+      public photos: AttachmentContract[]
+    }
+
+    User.after('delete', () => {
+      throw new Error('Failed')
+    })
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')
+
+        const user = await User.firstOrNew({ username: 'virk' }, {})
+        user.photos = file ? [Attachment.fromFile(file)] : []
+        await user.save()
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    const user = await User.firstOrFail()
+    const trx = await Db.transaction()
+
+    try {
+      await user.useTransaction(trx).delete()
+    } catch {
+      assert.isTrue(await Drive.exists(body.avatar.name))
+      await trx.rollback()
+    }
+
+    const users = await User.all()
+    assert.lengthOf(users, 1)
+    assert.deepEqual(users[0].photos[0]?.toJSON(), body.avatar)
+    assert.isTrue(await Drive.exists(body.avatar.name))
+  })
+})
+
+test.group('@attachment | multiple | find', (group) => {
+  group.setup(async () => {
+    app = await setupApplication()
+    await setup(app)
+
+    app.container.resolveBinding('Adonis/Core/Route').commit()
+    Attachment.setDrive(app.container.resolveBinding('Adonis/Core/Drive'))
+  })
+
+  group.each.teardown(async () => {
+    await app.container.resolveBinding('Adonis/Lucid/Database').connection().truncate('users')
+  })
+
+  group.teardown(async () => {
+    await cleanup(app)
+  })
+
+  test('pre compute url on find', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ preComputeUrl: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')!
+
+        const user = new User()
+        user.username = 'virk'
+        user.photos = [Attachment.fromFile(file)]
+        await user.save()
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body } = await supertest(server)
+      .post('/')
+      .attach('photo', join(__dirname, '../cat.jpeg'))
+
+    const user = await User.firstOrFail()
+    assert.instanceOf(user.photos[0], Attachment)
+    assert.isDefined(user.photos[0]?.url)
+    assert.isDefined(body.photos[0].url)
+
+    assert.isTrue(await Drive.exists(body.photos[0].name))
+  })
+
+  test('Attachment response should be null when column value is null', async ({ assert }) => {
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ preComputeUrl: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')!
+
+        let user = new User()
+        user.username = 'virk'
+        user.photos = file ? [Attachment.fromFile(file)] : []
+        await user.save()
+
+        user = await User.firstOrFail()
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body } = await supertest(server).post('/')
+
+    assert.isNull(body.avatar)
+  })
+
+  test('do not pre compute when preComputeUrl is not enabled', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ multiple: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('photo')!
+
+        const user = new User()
+        user.username = 'virk'
+        user.photos = [Attachment.fromFile(file)]
+        await user.save()
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body } = await supertest(server)
+      .post('/')
+      .attach('photo', join(__dirname, '../cat.jpeg'))
+
+    const user = await User.firstOrFail()
+    assert.instanceOf(user.photos[0], Attachment)
+    assert.isUndefined(user.photos[0]?.url)
+    assert.isUndefined(body.photos[0].url)
+
+    assert.isTrue(await Drive.exists(body.photos[0].name))
+  })
+})
+
+test.group('@attachment | multiple | fetch', (group) => {
+  group.setup(async () => {
+    app = await setupApplication()
+    await setup(app)
+
+    app.container.resolveBinding('Adonis/Core/Route').commit()
+    Attachment.setDrive(app.container.resolveBinding('Adonis/Core/Drive'))
+  })
+
+  group.each.teardown(async () => {
+    await app.container.resolveBinding('Adonis/Lucid/Database').connection().truncate('users')
+  })
+
+  group.teardown(async () => {
+    await cleanup(app)
+  })
+
+  test('pre compute url on fetch', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ preComputeUrl: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')!
+
+        const user = new User()
+        user.username = 'virk'
+        user.photos = [Attachment.fromFile(file)]
+        await user.save()
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    const users = await User.all()
+    assert.instanceOf(users[0].photos[0], Attachment)
+    assert.isDefined(users[0].photos[0]?.url)
+    assert.isDefined(body.avatar.url)
+
+    assert.isTrue(await Drive.exists(body.avatar.name))
+  })
+
+  test('Attachment response should be null when column value is null', async ({ assert }) => {
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ preComputeUrl: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        await Promise.all(
+          ['virk', 'ndianabasi'].map((username) => User.firstOrCreate({ username }))
+        )
+
+        const users = await User.all()
+
+        ctx.response.send(users)
+        ctx.response.finish()
+      })
+    })
+
+    await supertest(server).post('/')
+    const { body } = await supertest(server).post('/')
+
+    assert.isNull(body[0].avatar)
+    assert.isNull(body[1].avatar)
+  })
+
+  test('do not pre compute when preComputeUrl is not enabled', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ multiple: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')!
+
+        const user = new User()
+        user.username = 'virk'
+        user.photos = [Attachment.fromFile(file)]
+        await user.save()
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    const users = await User.all()
+    assert.instanceOf(users[0].photos[0], Attachment)
+    assert.isUndefined(users[0].photos[0]?.url)
+    assert.isUndefined(body.avatar.url)
+
+    assert.isTrue(await Drive.exists(body.avatar.name))
+  })
+})
+
+test.group('@attachment | multiple | paginate', (group) => {
+  group.setup(async () => {
+    app = await setupApplication()
+    await setup(app)
+
+    app.container.resolveBinding('Adonis/Core/Route').commit()
+    Attachment.setDrive(app.container.resolveBinding('Adonis/Core/Drive'))
+  })
+
+  group.each.teardown(async () => {
+    await app.container.resolveBinding('Adonis/Lucid/Database').connection().truncate('users')
+  })
+
+  group.teardown(async () => {
+    await cleanup(app)
+  })
+
+  test('pre compute url on paginate', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ preComputeUrl: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')!
+
+        const user = new User()
+        user.username = 'virk'
+        user.photos = [Attachment.fromFile(file)]
+        await user.save()
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    const users = await User.query().paginate(1)
+    assert.instanceOf(users[0].photos[0], Attachment)
+    assert.isDefined(users[0].photos[0]?.url)
+    assert.isDefined(body.avatar.url)
+
+    assert.isTrue(await Drive.exists(body.avatar.name))
+  })
+
+  test('Attachment response should be null when column value is null', async ({ assert }) => {
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ preComputeUrl: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        await Promise.all(
+          ['virk', 'ndianabasi'].map((username) => User.firstOrCreate({ username }))
+        )
+
+        const users = await User.query().paginate(1)
+
+        ctx.response.send(users)
+        ctx.response.finish()
+      })
+    })
+
+    const { body } = await supertest(server).post('/')
+
+    assert.isNull(body.data[0].avatar)
+    assert.isNull(body.data[1].avatar)
+  })
+
+  test('do not pre compute when preComputeUrl is not enabled', async ({ assert }) => {
+    const Drive = app.container.resolveBinding('Adonis/Core/Drive')
+    const { column, BaseModel } = app.container.use('Adonis/Lucid/Orm')
+    const HttpContext = app.container.resolveBinding('Adonis/Core/HttpContext')
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: string
+
+      @column()
+      public username: string
+
+      @attachment({ multiple: true })
+      public photos: AttachmentContract[]
+    }
+
+    const server = createServer((req, res) => {
+      const ctx = HttpContext.create('/', {}, req, res)
+
+      app.container.make(BodyParserMiddleware).handle(ctx, async () => {
+        const file = ctx.request.file('avatar')!
+
+        const user = new User()
+        user.username = 'virk'
+        user.photos = [Attachment.fromFile(file)]
+        await user.save()
+
+        ctx.response.send(user)
+        ctx.response.finish()
+      })
+    })
+
+    const { body } = await supertest(server)
+      .post('/')
+      .attach('avatar', join(__dirname, '../cat.jpeg'))
+
+    const users = await User.query().paginate(1)
+    assert.instanceOf(users[0].photos[0], Attachment)
+    assert.isUndefined(users[0].photos[0]?.url)
+    assert.isUndefined(body.avatar.url)
+
+    assert.isTrue(await Drive.exists(body.avatar.name))
+  })
+})

--- a/test/attachment.spec.ts
+++ b/test/attachment.spec.ts
@@ -42,10 +42,33 @@ test.group('Attachment | fromDbResponse', (group) => {
         extname: 'jpg',
         mimeType: 'image/jpg',
       })
-    )
+    ) as Attachment
 
     assert.isTrue(attachment?.isPersisted)
     assert.isFalse(attachment?.isLocal)
+  })
+
+  test('create attachment array from db response', ({ assert }) => {
+    const attachments = Attachment.fromDbResponse(
+      JSON.stringify([
+        {
+          size: 1440,
+          name: 'foo.jpg',
+          extname: 'jpg',
+          mimeType: 'image/jpg',
+        },
+        {
+          size: 1440,
+          name: 'foo.webp',
+          extname: 'webp',
+          mimeType: 'image/webp',
+        },
+      ])
+    ) as Attachment[]
+    attachments.forEach((attachment) => {
+      assert.isTrue(attachment?.isPersisted)
+      assert.isFalse(attachment?.isLocal)
+    })
   })
 
   test('save method should result in noop when attachment is created from db response', async ({


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Sometimes we need to attach multiple files to a model, e.g. a job application may contain CV, cover letter, portfolio, copy of degree certificates, etc.

This PR add an `multiple` option to the decorator. Like this:

```ts
class User extends BaseModel {
  @attachment({ multiple: true })
  public photos: AttachmentContract[]
}
```

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/attachment-lite/blob/master/.github/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
