### PR TITLE
Improvements to `setOptions` calls and `afterFind` hook

### DIFF
--- a/adonis-typings/attachment.ts
+++ b/adonis-typings/attachment.ts
@@ -93,6 +93,11 @@ declare module '@ioc:Adonis/Addons/AttachmentLite' {
     setOptions(options?: AttachmentOptions): this
 
     /**
+     * Attachment options
+     */
+    options?: AttachmentOptions
+
+    /**
      * Save file to the disk. Results if noop when "this.isLocal = false"
      */
     save(): Promise<void>

--- a/src/Attachment/decorator.ts
+++ b/src/Attachment/decorator.ts
@@ -41,7 +41,7 @@ async function persistAttachment(
    * remove the existing file.
    */
   if (existingFile && !newFile) {
-    existingFile.setOptions(options)
+    existingFile.setOptions({ ...existingFile.options, ...options })
     modelInstance['attachments'].detached.push(existingFile)
     return
   }
@@ -51,14 +51,14 @@ async function persistAttachment(
    * file.
    */
   if (newFile && newFile.isLocal) {
-    newFile.setOptions(options)
+    newFile.setOptions({ ...newFile.options, ...options })
     modelInstance['attachments'].attached.push(newFile)
 
     /**
      * If there was an existing file, then we must get rid of it
      */
     if (existingFile) {
-      existingFile.setOptions(options)
+      existingFile.setOptions({ ...existingFile.options, ...options })
       modelInstance['attachments'].detached.push(existingFile)
     }
 

--- a/src/Attachment/decorator.ts
+++ b/src/Attachment/decorator.ts
@@ -171,7 +171,10 @@ async function afterFind(modelInstance: LucidRow) {
   await Promise.all(
     modelInstance.constructor['attachments'].map(
       (attachmentField: { property: string; options?: AttachmentOptions }) => {
-        if (modelInstance[attachmentField.property]) {
+        if (
+          modelInstance[attachmentField.property] &&
+          modelInstance[attachmentField.property] instanceof Attachment
+        ) {
           modelInstance[attachmentField.property].setOptions(attachmentField.options)
           return modelInstance[attachmentField.property].computeUrl()
         }

--- a/src/Attachment/index.ts
+++ b/src/Attachment/index.ts
@@ -166,7 +166,7 @@ export class Attachment implements AttachmentContract {
    * Define persistance options
    */
   public setOptions(options?: AttachmentOptions) {
-    this.options = options
+    this.options = { ...this.options, ...(options || {}) }
     return this
   }
 


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

This PR fixes two critical issues observed while using this add-on.

1. The `options` set with `setOptions` on runtime are not remembered through the lifecycle of persistence operation. For example: `column.setOptions({folder: '123/abc'})` does not always work. After being set on the Attachment class' `options` object, the new option does not reflect when the decorator carries out persistence of the file.
2. When this add-on is used together with similar add-on (such as Adonis Responsive Attachment) within the same model, when the model hooks are executed, the attachment instance of other add-ons is passed into this add-on which leads to error as the methods of the other add-on's instance might not be available.


## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/attachment-lite/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
