### PR TITLE
added disk to attachment with ability to use disk on demand

### DIFF
--- a/adonis-typings/attachment.ts
+++ b/adonis-typings/attachment.ts
@@ -26,6 +26,7 @@ declare module '@ioc:Adonis/Addons/AttachmentLite' {
     size: number
     extname: string
     mimeType: string
+    disk?: string
   }
 
   /**

--- a/src/Attachment/decorator.ts
+++ b/src/Attachment/decorator.ts
@@ -173,6 +173,9 @@ async function afterFind(modelInstance: LucidRow) {
     modelInstance.constructor['attachments'].map(
       (attachmentField: { property: string; options?: AttachmentOptions }) => {
         if (modelInstance[attachmentField.property]) {
+          if (modelInstance[attachmentField.property].attributes?.disk) {
+            attachmentField.options.disk = modelInstance[attachmentField.property].attributes?.disk
+          }
           modelInstance[attachmentField.property].setOptions(attachmentField.options)
           return modelInstance[attachmentField.property].computeUrl()
         }

--- a/src/Attachment/index.ts
+++ b/src/Attachment/index.ts
@@ -279,6 +279,7 @@ export class Attachment implements AttachmentContract {
       extname: this.extname,
       size: this.size,
       mimeType: this.mimeType,
+      disk: this.getDisk().name,
     }
   }
 


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes
<img width="478" alt="Screenshot 2023-12-07 at 00 57 07" src="https://github.com/adonisjs/attachment-lite/assets/34090541/f80cd312-9f99-4372-9bdf-5d207b6dda9d">


- Ability to persist the attachement disk into the database
- Ability to use persisted disk from db to compute url

Changes above fixes issue when you try to switch from disk that has been used to create at least 1 attachment
either the url breaks or the application throws an error of not being able to retrieve a file metadata.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/attachment-lite/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
