### PR TITLE
add file client name to attachment attributes

### DIFF
--- a/adonis-typings/attachment.ts
+++ b/adonis-typings/attachment.ts
@@ -26,6 +26,7 @@ declare module '@ioc:Adonis/Addons/AttachmentLite' {
     size: number
     extname: string
     mimeType: string
+    clientName: string
   }
 
   /**

--- a/adonis-typings/attachment.ts
+++ b/adonis-typings/attachment.ts
@@ -73,6 +73,11 @@ declare module '@ioc:Adonis/Addons/AttachmentLite' {
     mimeType: string
 
     /**
+     * The file mimetype.
+     */
+    clientName: string
+
+    /**
      * "isLocal = true" means the instance is created locally
      * using the bodyparser file object
      */

--- a/src/Attachment/index.ts
+++ b/src/Attachment/index.ts
@@ -52,6 +52,7 @@ export class Attachment implements AttachmentContract {
       extname: file.extname!,
       mimeType: `${file.type}/${file.subtype}`,
       size: file.size!,
+      clientName: file.clientName,
     }
 
     return new Attachment(attributes, file)
@@ -117,6 +118,11 @@ export class Attachment implements AttachmentContract {
    * The file mimetype.
    */
   public mimeType = this.attributes.mimeType
+
+  /**
+   * The file clientName.
+   */
+  public clientName = this.attributes.clientName
 
   /**
    * "isLocal = true" means the instance is created locally
@@ -279,6 +285,7 @@ export class Attachment implements AttachmentContract {
       extname: this.extname,
       size: this.size,
       mimeType: this.mimeType,
+      clientName: this.clientName,
     }
   }
 


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

It adds clientName attachment attributes.
When users are uploading files, I want to preserve the name of the files so I can show them back on the frontend. This way the users can easily recognize their files.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/adonisjs/attachment-lite/blob/master/.github/CONTRIBUTING.md) doc
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments
fix #39 
